### PR TITLE
README: Fix samatra library dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Minimal web framework in the spirit of [Scalatra](http://www.scalatra.org]). The
 - sbt: 
 ```
 resolvers += "jitpack" at "https://jitpack.io",
-libraryDependencies += "com.github.springernature" %% "samatra" % "v1.5.0"	
+libraryDependencies += "com.github.springernature.samatra" %% "samatra" % "v1.5.0"	
 ```
 
 You may also be interested in [samatra-extras](https://github.com/springernature/samatra-extras) (which adds some dependencies but has more batteries included).


### PR DESCRIPTION
The groupID seems to have moved from com.github.springernature to com.github.springernature.samatra